### PR TITLE
Update parametric transistor generator to space out gate contacts

### DIFF
--- a/src/bus.rs
+++ b/src/bus.rs
@@ -23,14 +23,14 @@ pub enum ContactPosition {
 
 impl Pdk {
     /// The minimum spacing between tracks on a bus, assuming minimum sized contacts is used.
-    pub fn bus_min_spacing(&self, metal: LayerIdx, width: Int, strategy: ContactPolicy) -> Int {
+    pub fn bus_min_spacing(&self, metal: LayerIdx, width: Int, policy: ContactPolicy) -> Int {
         use std::cmp::{max, min};
 
         let tc = self.config.read().unwrap();
         let space = tc.layer(self.metal_name(metal)).space;
         let mut min_space = space;
 
-        if let Some(above) = strategy.above {
+        if let Some(above) = policy.above {
             let params = ContactParams::builder()
                 .stack(self.stack_name(metal).to_string())
                 .rows(1)
@@ -55,7 +55,7 @@ impl Pdk {
             }
         }
 
-        if let Some(below) = strategy.below {
+        if let Some(below) = policy.below {
             if metal == 0 {
                 panic!("Cannot contact the lowest metal layer from below ");
             }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -12,6 +12,7 @@ use crate::{config::Uint, Pdk};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize, derive_builder::Builder)]
 pub struct ContactParams {
+    #[builder(setter(into))]
     pub stack: String,
     pub rows: Uint,
     pub cols: Uint,


### PR DESCRIPTION
The parametric transistor generator now spaces out gate poly/licon
contacts, fixing spacing DRC violations when the previous generator
was used with more than two fingers.

This also improves single-finger transistors, which will now have
their gate contact centered.

The nitride poly cut manual merge DRC error is also fixed.

The NPC bounding box has been added to the list of bounding boxes
returned by the contact generator.
